### PR TITLE
fix: math error in tick updates during swaps

### DIFF
--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -459,8 +459,9 @@ export function handleSwap(event: SwapEvent): void {
   // Update inner vars of current or crossed ticks
   let newTick = pool.tick!
   let tickSpacing = feeTierToTickSpacing(pool.feeTier)
-  let modulo = newTick.mod(tickSpacing)
-  if (modulo.equals(ZERO_BI)) {
+  let newModulo = newTick.mod(tickSpacing)
+  let oldModulo = oldTick.mod(tickSpacing)
+  if (newModulo.equals(ZERO_BI)) {
     // Current tick is initialized and needs to be updated
     loadTickUpdateFeeVarsAndSave(newTick.toI32(), event)
   }
@@ -477,12 +478,12 @@ export function handleSwap(event: SwapEvent): void {
     // updated later. For early users this error also disappears when calling
     // collect
   } else if (newTick.gt(oldTick)) {
-    let firstInitialized = oldTick.plus(tickSpacing.minus(modulo))
+    let firstInitialized = oldTick.plus(tickSpacing.minus(oldModulo))
     for (let i = firstInitialized; i.le(newTick); i = i.plus(tickSpacing)) {
       loadTickUpdateFeeVarsAndSave(i.toI32(), event)
     }
   } else if (newTick.lt(oldTick)) {
-    let firstInitialized = oldTick.minus(modulo)
+    let firstInitialized = oldTick.minus(oldModulo)
     for (let i = firstInitialized; i.ge(newTick); i = i.minus(tickSpacing)) {
       loadTickUpdateFeeVarsAndSave(i.toI32(), event)
     }


### PR DESCRIPTION
Hello, 
It appears there's a bug in the tick section of **_handleSwap_** that result in ticks (and tickDayDatas) not getting updated when they should causing a mismatch between subgraph and blockchain data, see [1].

Using small numbers to describe the issue, let's assume a pool's state in which the current tick is 19 and a swap occurs that pushes the current tick to 21, and let's also assume a tick spacing of 10.

**_handleSwap_** in that example would compute `modulo = newTick.mod(tickSpacing)` == 1 and **_firstInitialized_** would thus be defined as `firstInitialized = oldTick.plus(tickSpacing.minus(modulo))` == 28. The correct value for **_firstInitialized_** should of course be 20 instead.

I'm syncing subgraph with the changes [here](https://thegraph.com/legacy-explorer/subgraph/mariorz/uniswapv3), but it still has a long way to go.

[1] I've noticed bogus subgraph data while rendering charts of daily fees for positions, but I believe [issue 44](https://github.com/Uniswap/v3-subgraph/issues/44) is a good example. I wrote a test to compare subgraph data with blockchain data at the specified block, uploaded [here](https://gist.github.com/mariorz/bf005b6ec8c9838b805e1dba60a593aa). Use brownie to run it: `brownie run tickstest.py --network mainnet`. 

Results:
```
Testing contract calls vs the graph values for
pool:0x4e68ccd3e89f51c3074ca5072bbac773960dfa36
tick:-195660
block:13010089
feeGrowthOutside0X128 from the blockchain: 1067292557275396938893002967958758719094
feeGrowthOutside0X128 from the graph     : 335883582520604181952009590658028448194028
Mismatch ✘

```
